### PR TITLE
Configured the permitted_classes option of YAML::load to include the Date class

### DIFF
--- a/lib/app_version/app_version.rb
+++ b/lib/app_version/app_version.rb
@@ -111,7 +111,7 @@ module App
     #
     # @param path [String] Yaml file name to load
     def self.load(path)
-      App::Version.new YAML.load(File.open(path))
+      App::Version.new YAML.load(File.open(path), permitted_classes: [Date])
     end
 
     #


### PR DESCRIPTION
Now the gem is compatible with ruby 3.2.2

There was a change in psych from [3.1](https://docs.ruby-lang.org/en/3.1/Psych.html#method-c-load) to [3.2.2](https://docs.ruby-lang.org/en/3.2/Psych.html#method-c-load) that throws the following error `Tried to load unspecified class: Date (Psych::DisallowedClass)`

